### PR TITLE
add initial github org profile readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,3 @@
+# Redpanda
+
+Redpanda is a modern streaming platform for mission critical workloads. Kafka API Compatible; 10x faster :rocket: See more at [redpanda.com](https://redpanda.com/).


### PR DESCRIPTION
GitHub announced org profiles in 2021-09-14 blog [post](https://github.blog/changelog/2021-09-14-readmes-for-organization-profiles/).

This PR adds a [GitHub organization profile README](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile#adding-an-organization-profile-readme) for redpanda-data.